### PR TITLE
fix(client): use authorization header instead of basic auth

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
     ruby2_keywords (0.0.5)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/log_snag/client.rb
+++ b/lib/log_snag/client.rb
@@ -19,7 +19,7 @@ module LogSnag
 
     def connection
       @connection ||= Faraday.new(BASE_URL) do |conn|
-        conn.request :authorization, :basic, token
+        conn.headers["Authorization"] = "Bearer #{token}"
         conn.request :json
         conn.response :json
         conn.adapter adapter, @stubs

--- a/lib/log_snag/client.rb
+++ b/lib/log_snag/client.rb
@@ -19,7 +19,7 @@ module LogSnag
 
     def connection
       @connection ||= Faraday.new(BASE_URL) do |conn|
-        conn.headers["Authorization"] = "Bearer #{token}"
+        conn.request :authorization, :Bearer, token
         conn.request :json
         conn.response :json
         conn.adapter adapter, @stubs


### PR DESCRIPTION
Basic authentication is not supported (anymore), therefore using Authorization header